### PR TITLE
Fixed checkbox icon display issue

### DIFF
--- a/public/images/icons/icon-check.svg
+++ b/public/images/icons/icon-check.svg
@@ -1,0 +1,1 @@
+<svg height="12" width="15" xmlns="http://www.w3.org/2000/svg"><path d="m1 6.57 3.572 3.572 9.142-9.142" fill="none" stroke="#fff" stroke-width="2"/></svg>

--- a/src/components/Checkbox.jsx
+++ b/src/components/Checkbox.jsx
@@ -1,7 +1,4 @@
-import { useState } from 'react';
 import styled from '@emotion/styled';
-
-import checkIcon from '../assets/images/icons/icon-check.svg';
 
 const CheckboxContainer = styled.div`
   display: flex;
@@ -26,9 +23,9 @@ const CheckboxInput = styled.input`
   &:checked {
     background-color: ${(props) => props.theme.checkbox.checkedBgColor};
     background-size: 65%;
-    background-position: center 60%;
+    background-position: center;
     background-repeat: no-repeat;
-    background-image: url(${checkIcon});
+    background-image: url('./images/icons/icon-check.svg');
   }
 `;
 


### PR DESCRIPTION
### Issue

N/A

### Type of change

- [x] Bug Fix: a non-breaking change that addresses an issue.

### Summary

The checkbox icon did not appear when users selected the checkbox on the live site, but it shows up in our local environment. It seems that this is a common problem in deploying Vite React apps to Github pages so the workaround to this problem is placing the images in the `/public` directory. 

### Testing steps

On the live site, click on the "Full-time Only" checkbox in the search bar component. A checkbox icon should show up when it is selected. 

### Relevant screenshots

N/A
